### PR TITLE
Add minimal transformer notebook

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,5 @@
+# Transformer Playground
 
+This repository contains a small Jupyter notebook demonstrating a toy Transformer model with live attention visualization.
+
+Open `mini_transformer_playground.ipynb` in Jupyter or Colab to train the model and see the animations.

--- a/mini_transformer_playground.ipynb
+++ b/mini_transformer_playground.ipynb
@@ -1,0 +1,225 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6b781e1a",
+   "metadata": {},
+   "source": [
+    "# Tiny Transformer Playground\n",
+    "\n",
+    "This notebook trains a very small Transformer model on a toy corpus and shows\n",
+    "live attention weights while training. All dependencies are standard PyPI\n",
+    "packages.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6222faff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q torch matplotlib ipywidgets tqdm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4988d93f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math, torch, torch.nn as nn, torch.nn.functional as F, random, matplotlib.pyplot as plt\n",
+    "from matplotlib import animation\n",
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9583e26",
+   "metadata": {},
+   "source": [
+    "## Hyper-parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69f04e06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as wd\n",
+    "cfg = {\n",
+    "    'emb':    wd.IntSlider(      32,  8,128,8 , description='Embed'),\n",
+    "    'heads':  wd.IntSlider(       2,  1,  8,1 , description='Heads'),\n",
+    "    'layers': wd.IntSlider(       2,  1,  6,1 , description='Layers'),\n",
+    "    'seq':    wd.IntSlider(      16,  4, 32,4 , description='SeqLen'),\n",
+    "    'bs':     wd.IntSlider(      32,  4,128,4 , description='Batch'),\n",
+    "    'steps':  wd.IntSlider(    1000,100,3000,100, description='Train steps')\n",
+    "}\n",
+    "display(*cfg.values())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1fc5569",
+   "metadata": {},
+   "source": [
+    "## Toy corpus and dataloader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a182cd23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text  = ('the quick brown fox jumps over the lazy dog ' * 200).split()\n",
+    "vocab = sorted(set(text)); stoi={w:i for i,w in enumerate(vocab)}; itos={i:w for w,i in stoi.items()}\n",
+    "vsz   = len(vocab)\n",
+    "\n",
+    "def batch(bs, seq):\n",
+    "    while True:\n",
+    "        s = random.randint(0, len(text)-seq-2)\n",
+    "        ids = [stoi[w] for w in text[s:s+seq+1]]\n",
+    "        x,y = ids[:-1], ids[1:]\n",
+    "        yield torch.tensor(x), torch.tensor(y)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3eb8fb9d",
+   "metadata": {},
+   "source": [
+    "## Mini-Transformer implementation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e13e7512",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class TinyTransformer(nn.Module):\n",
+    "    def __init__(self, vsz, emb, heads, layers, seq):\n",
+    "        super().__init__()\n",
+    "        self.tok   = nn.Embedding(vsz, emb)\n",
+    "        self.pos   = nn.Parameter(torch.randn(seq, emb))\n",
+    "        self.blocks= nn.ModuleList([\n",
+    "            nn.TransformerEncoderLayer(d_model=emb,\n",
+    "                                       nhead=heads,\n",
+    "                                       dim_feedforward=2*emb,\n",
+    "                                       batch_first=True,\n",
+    "                                       norm_first=True,\n",
+    "                                       dropout=0.0)\n",
+    "            for _ in range(layers)])\n",
+    "        self.ln_out= nn.LayerNorm(emb)\n",
+    "        self.head  = nn.Linear(emb, vsz, bias=False)\n",
+    "    def forward(self, x):\n",
+    "        B,T = x.shape\n",
+    "        h = self.tok(x) + self.pos[:T]\n",
+    "        for blk in self.blocks:         # save last block's attn map for visualization\n",
+    "            h, attn = blk.self_attn_output = blk.self_attn(h, h, h,\n",
+    "                                                           need_weights=True,\n",
+    "                                                           average_attn_weights=False)\n",
+    "        return self.head(self.ln_out(h)), attn           # attn: (B, heads, T, T)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11960a54",
+   "metadata": {},
+   "source": [
+    "## Training loop with live plots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87b75cb1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train(cfg):\n",
+    "    device='cuda' if torch.cuda.is_available() else 'cpu'\n",
+    "    net = TinyTransformer(vsz, cfg['emb'].value,\n",
+    "                          cfg['heads'].value,\n",
+    "                          cfg['layers'].value,\n",
+    "                          cfg['seq'].value).to(device)\n",
+    "    opt = torch.optim.AdamW(net.parameters(), lr=2e-3)\n",
+    "    gen = batch(cfg['bs'].value, cfg['seq'].value)\n",
+    "    \n",
+    "    # --- live plot set-up ---\n",
+    "    fig,(ax_loss,ax_attn) = plt.subplots(1,2, figsize=(10,4))\n",
+    "    losses,xdata = [],[]\n",
+    "    im = ax_attn.imshow(torch.zeros(cfg['seq'].value, cfg['seq'].value),\n",
+    "                        vmin=0, vmax=1, cmap='viridis')\n",
+    "    ttl = ax_attn.set_title('Attention')\n",
+    "    ln, = ax_loss.plot([],[], lw=2); ax_loss.set_ylabel('loss'); ax_loss.set_xlim(0,cfg['steps'].value)\n",
+    "    \n",
+    "    def _step(i):\n",
+    "        net.train(); x,y = next(gen); x,y = x.to(device), y.to(device)\n",
+    "        opt.zero_grad()\n",
+    "        logits, attn = net(x)\n",
+    "        loss = F.cross_entropy(logits.reshape(-1,vsz), y.flatten())\n",
+    "        loss.backward(); opt.step()\n",
+    "        # log\n",
+    "        losses.append(loss.item()); xdata.append(i)\n",
+    "        ln.set_data(xdata, losses); ax_loss.set_ylim(0,max(losses))\n",
+    "        # show last-head attention for first sample\n",
+    "        att = attn[0,-1].detach().cpu()\n",
+    "        im.set_data(att); ttl.set_text('Step %d  Head-%d'%(i,attn.shape[1]-1))\n",
+    "        return ln, im\n",
+    "    \n",
+    "    anim = animation.FuncAnimation(fig, _step, interval=50,\n",
+    "                                   frames=cfg['steps'].value, blit=False)\n",
+    "    plt.close(fig); display(anim)\n",
+    "    return net\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "419c8c3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trained = train(cfg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e140667",
+   "metadata": {},
+   "source": [
+    "## Using the model interactively"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87ca7cac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def predict(prompt, net, max_new=20):\n",
+    "    net.eval()\n",
+    "    toks = [stoi[w] for w in prompt.split()]\n",
+    "    for _ in range(max_new):\n",
+    "        x = torch.tensor(toks[-cfg['seq'].value:]).unsqueeze(0)\n",
+    "        logits,_ = net(x)\n",
+    "        next_id  = logits[0,-1].argmax().item()\n",
+    "        toks.append(next_id)\n",
+    "    return ' '.join(itos[i] for i in toks)\n",
+    "\n",
+    "print(predict('the quick brown', trained, 10))\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Jupyter notebook with a tiny transformer playground
- document how to run it

## Testing
- `python - <<'PY'
import nbformat
nbformat.read('mini_transformer_playground.ipynb', as_version=4)
print('notebook OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68499ad5bf14832188898c52801cf7af